### PR TITLE
v0.0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OSMMakie"
 uuid = "76b6901f-8821-46bb-9129-841bc9cfe677"
 authors = ["Frederik Banning <frederik.banning@ruhr-uni-bochum.de>"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ osm = graph_from_file("london_drive.json";
 fig, ax, plot = osmplot(osm)
 ax.aspect = DataAspect()
 display(fig)
+
+# enable node and edge inspection
+DataInspector(fig)
 ```
 
 ![London map]()

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ However, users have full control over every aspect of the plot and can style the
 
 ## Usage example
 
+> The package is not yet registered and therefore impossible to add via `]add OSMMakie`. 
+> It is instead necessary to add it via the github link, i.e. `]add https://github.com/fbanning/OSMMakie.jl`.
+
 ```julia
 using LightOSM
 using OSMMakie

--- a/src/OSMMakie.jl
+++ b/src/OSMMakie.jl
@@ -5,54 +5,8 @@ using GraphMakie
 using Graphs
 using Makie
 
-include("OSMMakie_defaults.jl")
-
-##########################################################################################
-# OSMPlot recipe
-##########################################################################################
-
-"""
-Define OSMPlot plotting function with some attribute defaults.
-
-*arguments*
-
-osm::OSMGraph # OSMGraph object from LightOSM package
-
-*keyword arguments*
-
-graphplotkwargs = NamedTuple # kwargs to be passed on to graphplot recipe
-hide_elabels = false # show edge labels
-hide_nlabels = true # hide node labels
-osm_elabels = nothing # used internally for hide_elabels
-osm_nlabels = nothing # used internally for hide_nlabels
-"""
-@recipe(OSMPlot, osm) do scene
-    Attributes(
-        graphplotkwargs = NamedTuple(),
-        hide_elabels = false,
-        hide_nlabels = true,
-        osm_elabels = nothing,
-        osm_nlabels = nothing,
-    )
-end
-
-function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
-    # Node positions
-    node_pos = Point2.(reverse.(osmplot.osm[].node_coordinates))
-
-    # OSMMakie defaults
-    edge_defaults = set_edge_defaults(osmplot)
-    node_defaults = set_node_defaults(osmplot, edge_defaults.edge_width)
-
-    # Create the graphplot
-    graphplot!(osmplot, osmplot.osm[].graph;
-        layout = _ -> node_pos,
-        node_defaults...,
-        edge_defaults...,
-        osmplot.graphplotkwargs...
-    )
-
-    return osmplot
-end
+include("recipe.jl")
+include("defaults.jl")
+include("inspection.jl")
 
 end # module

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -49,7 +49,7 @@ function set_edge_defaults(osmplot)
         osm.edge_to_highway, osm.highways)
     edge_width = width_streets(sorted_edges, osm.index_to_node,
         osm.edge_to_highway, osm.highways)
-    elabels = osmplot.hide_elabels[] ? nothing : osmplot.osm_elabels[]
+    elabels = show_elabels(osmplot.hide_elabels[], osmplot.osm_elabels[])
     elabels_textsize = 11
     arrow_size = arrows_streets(sorted_edges, osm.index_to_node,
         osm.edge_to_highway, osm.highways)
@@ -111,6 +111,10 @@ function label_streets(sorted_edges, n2i, ways)
     end
 
     return labels
+end
+
+function show_elabels(hide_elabels, osm_elabels)
+    return hide_elabels ? nothing : osm_elabels
 end
 
 function arrows_streets(sorted_edges, i2n, e2h, ways)

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -17,15 +17,15 @@ end
 
 function node_sizes(osm)
     gv = vertices(osm.graph)
-    node_sizes = fill(1, length(gv))
+    sizes = fill(1, length(gv))
 
     for i in gv
         n = osm.index_to_node[i]
         w = osm.node_to_highway[n]
-        node_sizes[i] = length(w)
+        sizes[i] = length(w)
     end
 
-    return node_sizes
+    return sizes
 end
 
 function show_nlabels(hide_nlabels, osm_nlabels)

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -87,7 +87,7 @@ function label_streets(sorted_edges, n2i, ways)
                 end
                 [n2i[way.nodes[n1]], n2i[way.nodes[n2]]]
             end
-            i = indexin([node_indices], sorted_edges)[1]
+            i = only(indexin([node_indices], sorted_edges))
             labels[i] = way.tags["name"]
         end
     end

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -39,4 +39,41 @@ end
 # Edge inspection on mouse hover
 ##########################################################################################
 
-# TODO
+function Makie.show_data(inspector::DataInspector,
+    plot::OSMPlot{<:Tuple{<:OSMGraph}}, idx, source::LineSegments)
+    osm = plot.osm[]
+    a = inspector.plot.attributes
+    scene = Makie.parent_scene(plot)
+
+    p0, p1 = source[1][][idx-1:idx]
+    origin, dir = Makie.view_ray(scene)
+    pos = Makie.closest_point_on_line(p0, p1, origin, dir)
+    lw = source.linewidth[] isa Vector ? source.linewidth[][idx] : source.linewidth[]
+
+    proj_pos = Makie.shift_project(scene, plot, to_ndim(Point3f, pos, 0))
+    Makie.update_tooltip_alignment!(inspector, proj_pos)
+
+    # TODO nearest_node may pick wrong nodes because it takes the two nearest to cursor pos
+    # -> should somehow directly search for edge which goes through cursor pos
+    nn = nearest_node(osm, collect(pos), 2)[1][1]
+    way = osm.edge_to_highway[nn]
+    a._display_text[] = edge2string(osm.highways[way])
+    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* lw .- Vec2f(5), Vec2f(lw) .+ Vec2f(10))
+    a._px_bbox_visible[] = true
+    a._bbox_visible[] = false
+    a._visible[] = true
+
+    return true
+end
+
+function edge2string(edge::E) where {E<:LightOSM.Way}
+    edgestring = "▶ $(nameof(E)) $(edge.id)\n"
+
+    edgestring *= "$(edge.nodes)\n"
+
+    for (key, val) in pairs(edge.tags)
+        edgestring *= "$(key): $(val)\n"
+    end
+
+    return edgestring
+end

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -3,16 +3,18 @@
 ##########################################################################################
 
 function Makie.show_data(inspector::DataInspector,
-    plot::GraphPlot{<:Tuple{<:AbstractGraph}}, idx, ::Scatter)
+    plot::OSMPlot{<:Tuple{<:OSMGraph}}, idx, source::Scatter)
+    osm = plot.osm[]
     a = inspector.plot.attributes
     scene = Makie.parent_scene(plot)
 
-    proj_pos = Makie.shift_project(scene, plot, to_ndim(Point3f0, plot[1][][idx], 0))
+    pos = source[1][][idx]
+    proj_pos = Makie.shift_project(scene, plot, to_ndim(Point3f, pos, 0))
     Makie.update_tooltip_alignment!(inspector, proj_pos)
-    ms = plot.markersize[]
 
-    cursor_pos = collect(plot[1][][idx].data[1], plot[1][][idx].data[2])
-    a._display_text[] = node2string(plot.parent.osm[], Float64.(cursor_pos))
+    nn = nearest_node(osm, collect(pos))[1][1][1]
+    a._display_text[] = node2string(osm.nodes[nn])
+    ms = source.markersize[][osm.node_to_index[nn]]
     a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
     a._px_bbox_visible[] = true
     a._bbox_visible[] = false
@@ -21,19 +23,12 @@ function Makie.show_data(inspector::DataInspector,
     return true
 end
 
-function node2string(osm::LightOSM.OSMGraph, cursor_pos::Vector{Float64})
-    nn = nearest_node(osm, cursor_pos)[1][1][1]
-    return node2string(osm.nodes[nn])
-end
-
 function node2string(node::N) where {N<:LightOSM.Node}
-    nodestring = "▶ $(nameof(N))\n"
+    nodestring = "▶ $(nameof(N)) $(node.id)\n"
 
-    nodestring *= "id: $(node.id)\n"
+    nodestring *= "$(node.location)"
 
-    nodestring *= "GeoLocation: $(node.nodes)\n"
-
-    for (key, val) in Pairs(node.tags)
+    for (key, val) in pairs(node.tags)
         nodestring *= "$(key): $(val)\n"
     end
 

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -13,6 +13,7 @@ function Makie.show_data(inspector::DataInspector,
     Makie.update_tooltip_alignment!(inspector, proj_pos)
 
     nn = nearest_node(osm, collect(pos))[1][1][1]
+    # TODO tooltip works but doesn't update
     a._display_text[] = node2string(osm.nodes[nn])
     ms = source.markersize[][osm.node_to_index[nn]]
     a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
@@ -34,6 +35,8 @@ function node2string(node::N) where {N<:LightOSM.Node}
 
     return nodestring
 end
+
+# TODO copy current node ID on click
 
 ##########################################################################################
 # Edge inspection on mouse hover
@@ -57,6 +60,7 @@ function Makie.show_data(inspector::DataInspector,
     # -> should somehow directly search for edge which goes through cursor pos
     nn = nearest_node(osm, collect(pos), 2)[1][1]
     way = osm.edge_to_highway[nn]
+    # TODO tooltip works but doesn't update
     a._display_text[] = edge2string(osm.highways[way])
     a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* lw .- Vec2f(5), Vec2f(lw) .+ Vec2f(10))
     a._px_bbox_visible[] = true
@@ -69,6 +73,7 @@ end
 function edge2string(edge::E) where {E<:LightOSM.Way}
     edgestring = "▶ $(nameof(E)) $(edge.id)\n"
 
+    # TODO maybe sensible to remove edge nodes vector from tooltip in the end
     edgestring *= "$(edge.nodes)\n"
 
     for (key, val) in pairs(edge.tags)
@@ -77,3 +82,5 @@ function edge2string(edge::E) where {E<:LightOSM.Way}
 
     return edgestring
 end
+
+# TODO copy current edge ID on click

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -17,7 +17,7 @@ function Makie.show_data(inspector::DataInspector,
     ms = plot.markersize[]
 
     cursor_pos = collect(plot[1][][idx].data[1], plot[1][][idx].data[2])
-    a._display_text[] = node2string(plot.parent.osm[], round.(Float64.(cursor_pos), digits = 7))
+    a._display_text[] = node2string(plot.parent.osm[], Float64.(cursor_pos))
     a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
     a._px_bbox_visible[] = true
     a._bbox_visible[] = false
@@ -27,13 +27,8 @@ function Makie.show_data(inspector::DataInspector,
 end
 
 function node2string(osm::LightOSM.OSMGraph, cursor_pos::Vector{Float64})
-    i = only(indexin(cursor_pos, osm.node_coordinates))
-    if isnothing(i)
-        return ""
-    else
-        node = osm.nodes[i]
-        return node2string(node)
-    end
+    nn = nearest_node(osm, cursor_pos)[1][1][1]
+    return node2string(osm.nodes[nn])
 end
 
 function node2string(node::N) where {N<:LightOSM.Node}

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -1,8 +1,3 @@
-function Makie.show_data(inspector::DataInspector,
-    plot::OSMPlot{<:Tuple{<:OSMGraph}}, idx, gp::GraphPlot)
-    return Makie.show_data(inspector, gp, idx)
-end
-
 ##########################################################################################
 # Node inspection on mouse hover
 ##########################################################################################

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -17,7 +17,6 @@ function Makie.show_data(inspector::DataInspector,
     ms = plot.markersize[]
 
     cursor_pos = collect(plot[1][][idx].data[1], plot[1][][idx].data[2])
-    println("test")
     a._display_text[] = node2string(plot.parent.osm[], round.(Float64.(cursor_pos), digits = 7))
     a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
     a._px_bbox_visible[] = true

--- a/src/inspection.jl
+++ b/src/inspection.jl
@@ -1,0 +1,58 @@
+function Makie.show_data(inspector::DataInspector,
+    plot::OSMPlot{<:Tuple{<:OSMGraph}}, idx, gp::GraphPlot)
+    return Makie.show_data(inspector, gp, idx)
+end
+
+##########################################################################################
+# Node inspection on mouse hover
+##########################################################################################
+
+function Makie.show_data(inspector::DataInspector,
+    plot::GraphPlot{<:Tuple{<:AbstractGraph}}, idx, ::Scatter)
+    a = inspector.plot.attributes
+    scene = Makie.parent_scene(plot)
+
+    proj_pos = Makie.shift_project(scene, plot, to_ndim(Point3f0, plot[1][][idx], 0))
+    Makie.update_tooltip_alignment!(inspector, proj_pos)
+    ms = plot.markersize[]
+
+    cursor_pos = collect(plot[1][][idx].data[1], plot[1][][idx].data[2])
+    println("test")
+    a._display_text[] = node2string(plot.parent.osm[], round.(Float64.(cursor_pos), digits = 7))
+    a._bbox2D[] = Rect2f(proj_pos .- 0.5 .* ms .- Vec2f(5), Vec2f(ms) .+ Vec2f(10))
+    a._px_bbox_visible[] = true
+    a._bbox_visible[] = false
+    a._visible[] = true
+
+    return true
+end
+
+function node2string(osm::LightOSM.OSMGraph, cursor_pos::Vector{Float64})
+    i = only(indexin(cursor_pos, osm.node_coordinates))
+    if isnothing(i)
+        return ""
+    else
+        node = osm.nodes[i]
+        return node2string(node)
+    end
+end
+
+function node2string(node::N) where {N<:LightOSM.Node}
+    nodestring = "▶ $(nameof(N))\n"
+
+    nodestring *= "id: $(node.id)\n"
+
+    nodestring *= "GeoLocation: $(node.nodes)\n"
+
+    for (key, val) in Pairs(node.tags)
+        nodestring *= "$(key): $(val)\n"
+    end
+
+    return nodestring
+end
+
+##########################################################################################
+# Edge inspection on mouse hover
+##########################################################################################
+
+# TODO

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -45,5 +45,7 @@ function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
         osmplot.graphplotkwargs...
     )
 
+    # TODO disable node/edge inspection if hide_nlabels/hide_elabels
+
     return osmplot
 end

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -56,6 +56,7 @@ function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
 
     # Create the graphplot
     # User-provided graphplotkwargs will overwrite defaults
+    plot = graphplot!(osmplot, osmplot.osm[].graph;
         layout = _ -> node_pos,
         node_defaults...,
         edge_defaults...,
@@ -63,6 +64,9 @@ function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
     )
 
     # TODO add kwargs to toggle node/edge inspection
+
+    # Disable inspection for one-way arrows
+    plot.plots[2].inspectable[] = false
 
     return osmplot
 end

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -1,0 +1,49 @@
+export OSMPlot, osmplot, osmplot!
+
+##########################################################################################
+# OSMPlot recipe
+##########################################################################################
+
+"""
+Define OSMPlot plotting function with some attribute defaults.
+
+*arguments*
+
+osm::OSMGraph # OSMGraph object from LightOSM package
+
+*keyword arguments*
+
+graphplotkwargs = NamedTuple # kwargs to be passed on to graphplot recipe
+hide_elabels = false # show edge labels
+hide_nlabels = true # hide node labels
+osm_elabels = nothing # used internally for hide_elabels
+osm_nlabels = nothing # used internally for hide_nlabels
+"""
+@recipe(OSMPlot, osm) do scene
+    Attributes(
+        graphplotkwargs = NamedTuple(),
+        hide_elabels = false,
+        hide_nlabels = true,
+        osm_elabels = nothing,
+        osm_nlabels = nothing,
+    )
+end
+
+function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
+    # Node positions
+    node_pos = Point2.(reverse.(osmplot.osm[].node_coordinates))
+
+    # OSMMakie defaults
+    edge_defaults = set_edge_defaults(osmplot)
+    node_defaults = set_node_defaults(osmplot, edge_defaults.edge_width)
+
+    # Create the graphplot
+    graphplot!(osmplot, osmplot.osm[].graph;
+        layout = _ -> node_pos,
+        node_defaults...,
+        edge_defaults...,
+        osmplot.graphplotkwargs...
+    )
+
+    return osmplot
+end

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -34,8 +34,8 @@ function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
     node_pos = Point2.(reverse.(osmplot.osm[].node_coordinates))
 
     # OSMMakie defaults
+    node_defaults = set_node_defaults(osmplot)
     edge_defaults = set_edge_defaults(osmplot)
-    node_defaults = set_node_defaults(osmplot, edge_defaults.edge_width)
 
     # Create the graphplot
     graphplot!(osmplot, osmplot.osm[].graph;

--- a/src/recipe.jl
+++ b/src/recipe.jl
@@ -46,21 +46,23 @@ function Makie.plot!(osmplot::OSMPlot{<:Tuple{<:OSMGraph}})
     )
 
     # Node positions
+    # OSMGraph.node_coordinates is in lat/lon format. Reversing it provides lon/lat 
+    # which then creates standard north-oriented maps.
     node_pos = Point2.(reverse.(osmplot.osm[].node_coordinates))
 
-    # OSMMakie defaults
+    # OSMMakie defaults (see defaults.jl for details)
     node_defaults = set_node_defaults(osmplot)
     edge_defaults = set_edge_defaults(osmplot)
 
     # Create the graphplot
-    graphplot!(osmplot, osmplot.osm[].graph;
+    # User-provided graphplotkwargs will overwrite defaults
         layout = _ -> node_pos,
         node_defaults...,
         edge_defaults...,
         osmplot.graphplotkwargs...
     )
 
-    # TODO disable node/edge inspection if hide_nlabels/hide_elabels
+    # TODO add kwargs to toggle node/edge inspection
 
     return osmplot
 end


### PR DESCRIPTION
- Complete rework of the project structure
- Closes #1 (hopefully)
- Adds inspection on mouse over (enabled via `DataInspector(fig)`)
    - By default provides tooltips for both edges and nodes
    - Disable node inspection via `plot.plots[1].plots[3].inspectable[] = false`
    - Disable edge inspection via `plot.plots[1].plots[1].inspectable[] = false`
    - Arrows for one-way streets are not inspectable by default